### PR TITLE
[WIP] Major refactor, to support missing-node errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,7 @@ pub enum TrieError {
     InvalidData,
     InvalidStateRoot,
     InvalidProof,
+    Invariant(String),
 }
 
 impl Error for TrieError {}

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -10,6 +10,10 @@ impl Nibbles {
         Nibbles { hex_data: hex }
     }
 
+    pub fn empty() -> Self {
+        Nibbles { hex_data: vec![] }
+    }
+
     pub fn from_raw(raw: Vec<u8>, is_leaf: bool) -> Self {
         let mut hex_data = vec![];
         for item in raw.into_iter() {

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -2,6 +2,7 @@ use std::cmp::min;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Nibbles {
+    // TODO When the special 16-value is dropped, then this should be reduced to u4
     hex_data: Vec<u8>,
 }
 
@@ -14,6 +15,8 @@ impl Nibbles {
         Nibbles { hex_data: vec![] }
     }
 
+    // TODO accept u8 slice?
+    // TODO drop is_leaf?
     pub fn from_raw(raw: Vec<u8>, is_leaf: bool) -> Self {
         let mut hex_data = vec![];
         for item in raw.into_iter() {


### PR DESCRIPTION
Just taking the first steps toward supporting errors that detail missing trie nodes. These are designed to enable handling partial-data situations, where trie nodes can be retrieved on-demand if missing. (Currently motivated by the Portal Network, but also useful for things like Beam Sync)