### PR TITLE
Add error for missing db entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ homepage = "https://github.com/carver/eth-trie.rs"
 documentation = "https://docs.rs/eth_trie"
 
 [dependencies]
-parking_lot = "0.8"
-rlp = "0.3.0"
 hashbrown = "0.3.0"
 hasher = { version = "0.1", features = ["hash-keccak"] }
+log = "0.4.14"
+parking_lot = "0.8"
+rlp = "0.3.0"
 
 [dev-dependencies]
 rand = "0.6.3"

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,7 +19,7 @@ pub trait DB: Send + Sync {
     /// Insert data into the cache.
     fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Self::Error>;
 
-    /// Insert data into the cache.
+    /// Remove data with given key.
     fn remove(&self, key: &[u8]) -> Result<(), Self::Error>;
 
     /// Insert a batch of data into the cache.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,8 @@ use std::fmt;
 
 use rlp::DecoderError;
 
+use crate::nibbles::Nibbles;
+
 #[derive(Debug)]
 pub enum TrieError {
     DB(String),
@@ -10,6 +12,12 @@ pub enum TrieError {
     InvalidData,
     InvalidStateRoot,
     InvalidProof,
+    MissingTrieNode {
+        node_hash: Vec<u8>,
+        traversed: Nibbles,
+        root_hash: Option<Vec<u8>>,
+        err_key: Option<Vec<u8>>,
+    },
 }
 
 impl Error for TrieError {}
@@ -22,6 +30,7 @@ impl fmt::Display for TrieError {
             TrieError::InvalidData => "trie error: invalid data".to_owned(),
             TrieError::InvalidStateRoot => "trie error: invalid state root".to_owned(),
             TrieError::InvalidProof => "trie error: invalid proof".to_owned(),
+            TrieError::MissingTrieNode { .. } => "trie error: missing node".to_owned(),
         };
         write!(f, "{}", printable)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ pub enum TrieError {
     InvalidProof,
     MissingTrieNode {
         node_hash: Vec<u8>,
-        traversed: Nibbles,
+        traversed: Option<Nibbles>,
         root_hash: Option<Vec<u8>>,
         err_key: Option<Vec<u8>>,
     },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TrieError {
     DB(String),
     Decoder(DecoderError),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,9 +19,9 @@ impl fmt::Display for TrieError {
         let printable = match *self {
             TrieError::DB(ref err) => format!("trie error: {:?}", err),
             TrieError::Decoder(ref err) => format!("trie error: {:?}", err),
-            TrieError::InvalidData => "trie error: invali data".to_owned(),
-            TrieError::InvalidStateRoot => "trie error: invali state root".to_owned(),
-            TrieError::InvalidProof => "trie error: invali proof".to_owned(),
+            TrieError::InvalidData => "trie error: invalid data".to_owned(),
+            TrieError::InvalidStateRoot => "trie error: invalid state root".to_owned(),
+            TrieError::InvalidProof => "trie error: invalid proof".to_owned(),
         };
         write!(f, "{}", printable)
     }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -803,7 +803,9 @@ where
         self.root_hash = root_hash.to_vec();
         self.gen_keys.borrow_mut().clear();
         self.passing_keys.borrow_mut().clear();
-        self.root = self.recover_from_db(&root_hash)?.unwrap();
+        self.root = self
+            .recover_from_db(&root_hash)?
+            .expect("The root that was just created is missing");
         Ok(root_hash)
     }
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -168,7 +168,7 @@ where
                     (TraceStatus::Doing, Node::Hash(ref hash_node)) => {
                         if let Ok(n) = self.trie.recover_from_db(&hash_node.borrow().hash.clone()) {
                             self.nodes.pop();
-                            self.nodes.push(n.into());
+                            self.nodes.push(n.unwrap().into());
                         } else {
                             //error!();
                             return None;
@@ -493,7 +493,7 @@ where
                 self.passing_keys
                     .borrow_mut()
                     .insert(borrow_hash_node.hash.to_vec());
-                let n = self.recover_from_db(&borrow_hash_node.hash)?;
+                let n = self.recover_from_db(&borrow_hash_node.hash)?.unwrap();
                 self.insert_at(n, partial, value)
             }
         }
@@ -551,7 +551,7 @@ where
                 let hash = hash_node.borrow().hash.clone();
                 self.passing_keys.borrow_mut().insert(hash.clone());
 
-                let n = self.recover_from_db(&hash)?;
+                let n = self.recover_from_db(&hash)?.unwrap();
                 self.delete_at(n, partial)
             }
         }?;
@@ -616,7 +616,7 @@ where
                         let hash = hash_node.borrow().hash.clone();
                         self.passing_keys.borrow_mut().insert(hash.clone());
 
-                        let new_node = self.recover_from_db(&hash)?;
+                        let new_node = self.recover_from_db(&hash)?.unwrap();
 
                         let n = Node::from_extension(borrow_ext.prefix.clone(), new_node);
                         self.degenerate(n)
@@ -660,7 +660,9 @@ where
                 }
             }
             Node::Hash(hash_node) => {
-                let n = self.recover_from_db(&hash_node.borrow().hash.clone())?;
+                let n = self
+                    .recover_from_db(&hash_node.borrow().hash.clone())?
+                    .unwrap();
                 let mut rest = self.get_path_at(n.clone(), partial)?;
                 rest.push(n);
                 Ok(rest)
@@ -704,7 +706,7 @@ where
         self.root_hash = root_hash.to_vec();
         self.gen_keys.borrow_mut().clear();
         self.passing_keys.borrow_mut().clear();
-        self.root = self.recover_from_db(&root_hash)?;
+        self.root = self.recover_from_db(&root_hash)?.unwrap();
         Ok(root_hash)
     }
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -160,8 +160,7 @@ where
                         let value_option = branch.borrow().value.clone();
                         if let Some(value) = value_option {
                             return Some((self.nibble.encode_raw().0, value));
-                        }
-                        else {
+                        } else {
                             continue;
                         }
                     }


### PR DESCRIPTION
Added a new `MissingTrieNode` error, to be used when a database entry is missing. It tracks various useful contextual tidbits.

Various trie methods like `get(..)`, `insert(..)`, etc. now return that error. This is helpful for filling an empty database, on the fly.

TODO:
- [x] add tests for MissingTrieNode, in all the scenarios:
  - [x] ~iterate~
  - [x] delete
  - [x] delete-refactor
  - [x] proof
  - [x] insert (note to self: already done, grab from other local branch)

The path traversed is a "nice to have." Looking back over trinity, it was only used during backfill to completely fill in the state database. So it's probably not that big a deal to return `None` sometimes for now. If that changes later, we can add the tracking of nibbles down from the root to the missing node, as needed.