### PR TITLE
PatriciaTrie -> EthTrie, with Keccak default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/eth_trie"
 
 [dependencies]
 hashbrown = "0.3.0"
-hasher = { version = "0.1", features = ["hash-keccak"] }
+keccak-hash = "0.8"
 log = "0.4.14"
 parking_lot = "0.8"
 rlp = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ strongly inspired by [go-ethereum trie](https://github.com/ethereum/go-ethereum/
 
 ## Features
 
-- Implementation of the Modified Patricia Tree
-- Custom hash algorithm (Keccak is provided by default)
+- Modified Patricia Tree, as used by Ethereum
 - Custom storage interface
 
 ## Example
@@ -20,29 +19,26 @@ strongly inspired by [go-ethereum trie](https://github.com/ethereum/go-ethereum/
 ```rust
 use std::sync::Arc;
 
-use hasher::{Hasher, HasherKeccak}; // https://crates.io/crates/hasher
-
 use eth_trie::MemoryDB;
-use eth_trie::{PatriciaTrie, Trie, TrieError};
+use eth_trie::{EthTrie, Trie, TrieError};
 
 fn main() -> Result<(), TrieError> {
     let memdb = Arc::new(MemoryDB::new(true));
-    let hasher = Arc::new(HasherKeccak::new());
 
     let key = b"test-key";
     let value = b"test-value";
 
     let root = {
-        let mut trie = PatriciaTrie::new(Arc::clone(&memdb), Arc::clone(&hasher));
+        let mut trie = EthTrie::new(Arc::clone(&memdb));
         trie.insert(key.to_vec(), value.to_vec())?;
 
         let v = trie.get(key)?;
         assert_eq!(Some(value.to_vec()), v);
-        trie.root()?
+        trie.root_hash()?
     };
-    assert_eq!(root, b"\x0ee/\xd2Y,\x8aS}\xcf|0\x85L\xb2\x87\xea\xabt\x0c\x16\xd9G\x0c\xa3\xe0S\xf4\x9b}\xe3g");
+    assert_eq!(root.as_bytes(), b"\x0ee/\xd2Y,\x8aS}\xcf|0\x85L\xb2\x87\xea\xabt\x0c\x16\xd9G\x0c\xa3\xe0S\xf4\x9b}\xe3g");
 
-    let mut trie = PatriciaTrie::from(Arc::clone(&memdb), Arc::clone(&hasher), &root)?;
+    let mut trie = EthTrie::from(Arc::clone(&memdb), root)?;
 
     let exists = trie.contains(key)?;
     assert_eq!(exists, true);
@@ -51,8 +47,8 @@ fn main() -> Result<(), TrieError> {
     assert_eq!(removed, true);
 
     // Back to the empty key after removing the only key
-    let new_root = trie.root()?;
-    assert_eq!(new_root, b"V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!");
+    let new_root = trie.root_hash()?;
+    assert_eq!(new_root.as_bytes(), b"V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n[H\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!");
 
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt;
 
+use keccak_hash::H256;
 use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;
@@ -15,7 +16,7 @@ pub enum TrieError {
     MissingTrieNode {
         node_hash: Vec<u8>,
         traversed: Option<Nibbles>,
-        root_hash: Option<Vec<u8>>,
+        root_hash: Option<H256>,
         err_key: Option<Vec<u8>>,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,3 @@
-//! ## Usage
-//!
-//! ```rust
-//! use std::sync::Arc;
-//!
-//! use hasher::{Hasher, HasherKeccak}; // https://crates.io/crates/hasher
-//!
-//! use eth_trie::MemoryDB;
-//! use eth_trie::{PatriciaTrie, Trie};
-
-//! let memdb = Arc::new(MemoryDB::new(true));
-//! let hasher = Arc::new(HasherKeccak::new());
-//!
-//! let key = "test-key".as_bytes();
-//! let value = "test-value".as_bytes();
-//!
-//! let root = {
-//!     let mut trie = PatriciaTrie::new(Arc::clone(&memdb), Arc::clone(&hasher));
-//!     trie.insert(key.to_vec(), value.to_vec()).unwrap();
-//!
-//!     let v = trie.get(key).unwrap();
-//!     assert_eq!(Some(value.to_vec()), v);
-//!     trie.root().unwrap()
-//! };
-//!
-//! let mut trie = PatriciaTrie::from(Arc::clone(&memdb), Arc::clone(&hasher), &root).unwrap();
-//! let exists = trie.contains(key).unwrap();
-//! assert_eq!(exists, true);
-//! let removed = trie.remove(key).unwrap();
-//! assert_eq!(removed, true);
-//! let new_root = trie.root().unwrap();
-//! println!("new root = {:?}", new_root);
-//! ```
-
 mod nibbles;
 mod node;
 mod tests;
@@ -42,7 +8,7 @@ mod trie;
 
 pub use db::{MemoryDB, DB};
 pub use errors::{MemDBError, TrieError};
-pub use trie::{PatriciaTrie, Trie};
+pub use trie::{EthTrie, Trie};
 
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]


### PR DESCRIPTION
Closes #7 
Also fixes #8 coincidentally

Use keccak-hash as default hashing library

Use the hashing library's `H256` type for node hashes. Also, use slices a couple more places, where appropriate.