### PR TITLE
Node hash type to H256

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
         executor:
             name: rust/default
             tag: 1.55.0
+        environment:
+            RUSTFLAGS: '-D warnings'
         steps:
             - checkout
             - run:
@@ -27,7 +29,10 @@ jobs:
                 command: cargo build --workspace --jobs 2
             - run:
                 name: Test workspace
-                command: RUSTFLAGS='-D warnings' cargo test --workspace
+                command: cargo test --workspace
+            - run:
+                name: Test benchmark compilability
+                command: cargo bench --workspace --no-run
 workflows:
   merge-test:
     jobs:

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -2,18 +2,14 @@ use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use hasher::HasherKeccak;
 use uuid::Uuid;
 
 use eth_trie::MemoryDB;
-use eth_trie::{PatriciaTrie, Trie};
+use eth_trie::{EthTrie, Trie};
 
 fn insert_worse_case_benchmark(c: &mut Criterion) {
     c.bench_function("eth-trie insert one", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
@@ -23,10 +19,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("eth-trie insert 1k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(1000);
         b.iter(|| {
@@ -37,10 +30,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("eth-trie insert 10k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(10000);
         b.iter(|| {

--- a/benches/trie.rs
+++ b/benches/trie.rs
@@ -2,18 +2,14 @@ use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use hasher::HasherKeccak;
 use uuid::Uuid;
 
 use eth_trie::MemoryDB;
-use eth_trie::{PatriciaTrie, Trie};
+use eth_trie::{EthTrie, Trie};
 
 fn insert_worse_case_benchmark(c: &mut Criterion) {
     c.bench_function("insert one", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
@@ -23,10 +19,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("insert 1k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(1000);
         b.iter(|| {
@@ -37,10 +30,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("insert 10k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(10000);
         b.iter(|| {
@@ -51,10 +41,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("get based 10k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {
@@ -68,10 +55,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("remove 1k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(1000);
         for i in 0..keys.len() {
@@ -86,10 +70,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("remove 10k", |b| {
-        let mut trie = PatriciaTrie::new(
-            Arc::new(MemoryDB::new(false)),
-            Arc::new(HasherKeccak::new()),
-        );
+        let mut trie = EthTrie::new(Arc::new(MemoryDB::new(false)));
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ pub enum TrieError {
     InvalidStateRoot,
     InvalidProof,
     MissingTrieNode {
-        node_hash: Vec<u8>,
+        node_hash: H256,
         traversed: Option<Nibbles>,
         root_hash: Option<H256>,
         err_key: Option<Vec<u8>>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use keccak_hash::H256;
+
 use crate::nibbles::Nibbles;
 
 #[derive(Debug, Clone)]
@@ -28,7 +30,7 @@ impl Node {
         Node::Extension(ext)
     }
 
-    pub fn from_hash(hash: Vec<u8>) -> Self {
+    pub fn from_hash(hash: H256) -> Self {
         let hash_node = Rc::new(RefCell::new(HashNode { hash }));
         Node::Hash(hash_node)
     }
@@ -69,7 +71,7 @@ pub struct ExtensionNode {
 
 #[derive(Debug)]
 pub struct HashNode {
-    pub hash: Vec<u8>,
+    pub hash: H256,
 }
 
 pub fn empty_children() -> [Node; 16] {


### PR DESCRIPTION
The node hash type was `Vec<u8>`. That is too loose, and keccak() returns a H256 type. So it's pretty natural to use the H256 type everywhere that's definitely a hash.

Fix #10 