### PR TITLE
Switch key and val of trie.insert(key, val) from Vec to slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fn main() -> Result<(), TrieError> {
 
     let root = {
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(key.to_vec(), value.to_vec())?;
+        trie.insert(key, value.to_vec())?;
 
         let v = trie.get(key)?;
         assert_eq!(Some(value.to_vec()), v);

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fn main() -> Result<(), TrieError> {
 
     let root = {
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(key, value.to_vec())?;
+        trie.insert(key, value)?;
 
         let v = trie.get(key)?;
         assert_eq!(Some(value.to_vec()), v);

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -14,7 +14,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
             let value = Uuid::new_v4().as_bytes().to_vec();
-            trie.insert(&key, value).unwrap()
+            trie.insert(&key, &value).unwrap()
         })
     });
 
@@ -24,7 +24,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(1000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(&keys[i], values[i].clone()).unwrap()
+                trie.insert(&keys[i], &values[i]).unwrap()
             }
         });
     });
@@ -35,7 +35,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(10000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(&keys[i], values[i].clone()).unwrap()
+                trie.insert(&keys[i], &values[i]).unwrap()
             }
         });
     });

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -14,7 +14,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
             let value = Uuid::new_v4().as_bytes().to_vec();
-            trie.insert(key, value).unwrap()
+            trie.insert(&key, value).unwrap()
         })
     });
 
@@ -24,7 +24,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(1000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+                trie.insert(&keys[i], values[i].clone()).unwrap()
             }
         });
     });
@@ -35,7 +35,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(10000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+                trie.insert(&keys[i], values[i].clone()).unwrap()
             }
         });
     });

--- a/benches/trie.rs
+++ b/benches/trie.rs
@@ -14,7 +14,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
             let value = Uuid::new_v4().as_bytes().to_vec();
-            trie.insert(key, value).unwrap()
+            trie.insert(&key, value).unwrap()
         })
     });
 
@@ -24,7 +24,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(1000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+                trie.insert(&keys[i], values[i].clone()).unwrap()
             }
         });
     });
@@ -35,7 +35,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(10000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+                trie.insert(&keys[i], values[i].clone()).unwrap()
             }
         });
     });
@@ -45,7 +45,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {
-            trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+            trie.insert(&keys[i], values[i].clone()).unwrap()
         }
 
         b.iter(|| {
@@ -59,7 +59,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(1000);
         for i in 0..keys.len() {
-            trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+            trie.insert(&keys[i], values[i].clone()).unwrap()
         }
 
         b.iter(|| {
@@ -74,7 +74,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {
-            trie.insert(keys[i].clone(), values[i].clone()).unwrap()
+            trie.insert(&keys[i], values[i].clone()).unwrap()
         }
 
         b.iter(|| {

--- a/benches/trie.rs
+++ b/benches/trie.rs
@@ -14,7 +14,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let key = Uuid::new_v4().as_bytes().to_vec();
             let value = Uuid::new_v4().as_bytes().to_vec();
-            trie.insert(&key, value).unwrap()
+            trie.insert(&key, &value).unwrap()
         })
     });
 
@@ -24,7 +24,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(1000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(&keys[i], values[i].clone()).unwrap()
+                trie.insert(&keys[i], &values[i]).unwrap()
             }
         });
     });
@@ -35,7 +35,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
         let (keys, values) = random_data(10000);
         b.iter(|| {
             for i in 0..keys.len() {
-                trie.insert(&keys[i], values[i].clone()).unwrap()
+                trie.insert(&keys[i], &values[i]).unwrap()
             }
         });
     });
@@ -45,7 +45,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {
-            trie.insert(&keys[i], values[i].clone()).unwrap()
+            trie.insert(&keys[i], &values[i]).unwrap()
         }
 
         b.iter(|| {
@@ -59,7 +59,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(1000);
         for i in 0..keys.len() {
-            trie.insert(&keys[i], values[i].clone()).unwrap()
+            trie.insert(&keys[i], &values[i]).unwrap()
         }
 
         b.iter(|| {
@@ -74,7 +74,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
 
         let (keys, values) = random_data(10000);
         for i in 0..keys.len() {
-            trie.insert(&keys[i], values[i].clone()).unwrap()
+            trie.insert(&keys[i], &values[i]).unwrap()
         }
 
         b.iter(|| {

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -6,13 +6,15 @@ pub struct Nibbles {
 }
 
 impl Nibbles {
-    pub fn from_hex(hex: Vec<u8>) -> Self {
-        Nibbles { hex_data: hex }
+    pub fn from_hex(hex: &[u8]) -> Self {
+        Nibbles {
+            hex_data: hex.to_vec(),
+        }
     }
 
-    pub fn from_raw(raw: Vec<u8>, is_leaf: bool) -> Self {
+    pub fn from_raw(raw: &[u8], is_leaf: bool) -> Self {
         let mut hex_data = vec![];
-        for item in raw.into_iter() {
+        for item in raw.iter() {
             hex_data.push(item / 16);
             hex_data.push(item % 16);
         }
@@ -22,7 +24,7 @@ impl Nibbles {
         Nibbles { hex_data }
     }
 
-    pub fn from_compact(compact: Vec<u8>) -> Self {
+    pub fn from_compact(compact: &[u8]) -> Self {
         let mut hex = vec![];
         let flag = compact[0];
 
@@ -128,7 +130,7 @@ impl Nibbles {
     }
 
     pub fn slice(&self, start: usize, end: usize) -> Nibbles {
-        Nibbles::from_hex(self.hex_data[start..end].to_vec())
+        Nibbles::from_hex(&self.hex_data[start..end])
     }
 
     pub fn get_data(&self) -> &[u8] {
@@ -136,10 +138,8 @@ impl Nibbles {
     }
 
     pub fn join(&self, b: &Nibbles) -> Nibbles {
-        let mut hex_data = vec![];
-        hex_data.extend_from_slice(self.get_data());
-        hex_data.extend_from_slice(b.get_data());
-        Nibbles::from_hex(hex_data)
+        let hex_data = [self.get_data(), b.get_data()].concat();
+        Nibbles::from_hex(&hex_data)
     }
 
     pub fn extend(&mut self, b: &Nibbles) {
@@ -165,9 +165,9 @@ mod tests {
 
     #[test]
     fn test_nibble() {
-        let n = Nibbles::from_raw(b"key1".to_vec(), true);
+        let n = Nibbles::from_raw(b"key1", true);
         let compact = n.encode_compact();
-        let n2 = Nibbles::from_compact(compact);
+        let n2 = Nibbles::from_compact(&compact);
         let (raw, is_leaf) = n2.encode_raw();
         assert_eq!(is_leaf, true);
         assert_eq!(raw, b"key1");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,7 +11,7 @@ mod trie_tests {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
         for (k, v) in data.into_iter() {
-            trie.insert(k, v.to_vec()).unwrap();
+            trie.insert(k, v).unwrap();
         }
         let root_hash = trie.root_hash().unwrap();
         let rs = format!("0x{}", hex::encode(root_hash.clone()));
@@ -550,9 +550,9 @@ mod trie_tests {
     fn test_proof_basic() {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(b"doe", b"reindeer".to_vec()).unwrap();
-        trie.insert(b"dog", b"puppy".to_vec()).unwrap();
-        trie.insert(b"dogglesworth", b"cat".to_vec()).unwrap();
+        trie.insert(b"doe", b"reindeer").unwrap();
+        trie.insert(b"dog", b"puppy").unwrap();
+        trie.insert(b"dogglesworth", b"cat").unwrap();
         let root = trie.root_hash().unwrap();
         let r = format!("0x{}", hex::encode(trie.root_hash().unwrap()));
         assert_eq!(
@@ -616,11 +616,11 @@ mod trie_tests {
             let random_bytes: Vec<u8> = (0..rng.gen_range(2, 30))
                 .map(|_| rand::random::<u8>())
                 .collect();
-            trie.insert(&random_bytes, random_bytes.clone()).unwrap();
+            trie.insert(&random_bytes, &random_bytes).unwrap();
             keys.push(random_bytes.clone());
         }
         for k in keys.clone().into_iter() {
-            trie.insert(&k, k.clone()).unwrap();
+            trie.insert(&k, &k).unwrap();
         }
         let root = trie.root_hash().unwrap();
         for k in keys.into_iter() {
@@ -643,7 +643,7 @@ mod trie_tests {
     fn test_proof_one_element() {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(b"k", b"v".to_vec()).unwrap();
+        trie.insert(b"k", b"v").unwrap();
         let root = trie.root_hash().unwrap();
         let proof = trie.get_proof(b"k").unwrap();
         assert_eq!(proof.len(), 1);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,7 +11,7 @@ mod trie_tests {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
         for (k, v) in data.into_iter() {
-            trie.insert(k.to_vec(), v.to_vec()).unwrap();
+            trie.insert(k, v.to_vec()).unwrap();
         }
         let root_hash = trie.root_hash().unwrap();
         let rs = format!("0x{}", hex::encode(root_hash.clone()));
@@ -550,10 +550,9 @@ mod trie_tests {
     fn test_proof_basic() {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(b"doe".to_vec(), b"reindeer".to_vec()).unwrap();
-        trie.insert(b"dog".to_vec(), b"puppy".to_vec()).unwrap();
-        trie.insert(b"dogglesworth".to_vec(), b"cat".to_vec())
-            .unwrap();
+        trie.insert(b"doe", b"reindeer".to_vec()).unwrap();
+        trie.insert(b"dog", b"puppy".to_vec()).unwrap();
+        trie.insert(b"dogglesworth", b"cat".to_vec()).unwrap();
         let root = trie.root_hash().unwrap();
         let r = format!("0x{}", hex::encode(trie.root_hash().unwrap()));
         assert_eq!(
@@ -617,12 +616,11 @@ mod trie_tests {
             let random_bytes: Vec<u8> = (0..rng.gen_range(2, 30))
                 .map(|_| rand::random::<u8>())
                 .collect();
-            trie.insert(random_bytes.to_vec(), random_bytes.clone())
-                .unwrap();
+            trie.insert(&random_bytes, random_bytes.clone()).unwrap();
             keys.push(random_bytes.clone());
         }
         for k in keys.clone().into_iter() {
-            trie.insert(k.clone(), k.clone()).unwrap();
+            trie.insert(&k, k.clone()).unwrap();
         }
         let root = trie.root_hash().unwrap();
         for k in keys.into_iter() {
@@ -645,7 +643,7 @@ mod trie_tests {
     fn test_proof_one_element() {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(Arc::clone(&memdb));
-        trie.insert(b"k".to_vec(), b"v".to_vec()).unwrap();
+        trie.insert(b"k", b"v".to_vec()).unwrap();
         let root = trie.root_hash().unwrap();
         let proof = trie.get_proof(b"k").unwrap();
         assert_eq!(proof.len(), 1);


### PR DESCRIPTION
It's more consistent with the rest of the API, and more convenient to pass in a borrowed value, to have key of insert() as a slice. It seemed silly to leave the value as a Vec, so I did both.