### PR TITLE
Thread safety

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, RwLock};
 
 use keccak_hash::H256;
 
@@ -8,30 +7,30 @@ use crate::nibbles::Nibbles;
 #[derive(Debug, Clone)]
 pub enum Node {
     Empty,
-    Leaf(Rc<RefCell<LeafNode>>),
-    Extension(Rc<RefCell<ExtensionNode>>),
-    Branch(Rc<RefCell<BranchNode>>),
-    Hash(Rc<RefCell<HashNode>>),
+    Leaf(Arc<RwLock<LeafNode>>),
+    Extension(Arc<RwLock<ExtensionNode>>),
+    Branch(Arc<RwLock<BranchNode>>),
+    Hash(Arc<RwLock<HashNode>>),
 }
 
 impl Node {
     pub fn from_leaf(key: Nibbles, value: Vec<u8>) -> Self {
-        let leaf = Rc::new(RefCell::new(LeafNode { key, value }));
+        let leaf = Arc::new(RwLock::new(LeafNode { key, value }));
         Node::Leaf(leaf)
     }
 
     pub fn from_branch(children: [Node; 16], value: Option<Vec<u8>>) -> Self {
-        let branch = Rc::new(RefCell::new(BranchNode { children, value }));
+        let branch = Arc::new(RwLock::new(BranchNode { children, value }));
         Node::Branch(branch)
     }
 
     pub fn from_extension(prefix: Nibbles, node: Node) -> Self {
-        let ext = Rc::new(RefCell::new(ExtensionNode { prefix, node }));
+        let ext = Arc::new(RwLock::new(ExtensionNode { prefix, node }));
         Node::Extension(ext)
     }
 
     pub fn from_hash(hash: H256) -> Self {
-        let hash_node = Rc::new(RefCell::new(HashNode { hash }));
+        let hash_node = Arc::new(RwLock::new(HashNode { hash }));
         Node::Hash(hash_node)
     }
 }
@@ -53,7 +52,7 @@ impl BranchNode {
         if i == 16 {
             match n {
                 Node::Leaf(leaf) => {
-                    self.value = Some(leaf.borrow().value.clone());
+                    self.value = Some(leaf.read().unwrap().value.clone());
                 }
                 _ => panic!("The n must be leaf node"),
             }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use hashbrown::{HashMap, HashSet};
 use keccak_hash::{keccak, H256};
@@ -135,12 +133,14 @@ where
                         match *node {
                             Node::Leaf(ref leaf) => {
                                 let cur_len = self.nibble.len();
-                                self.nibble.truncate(cur_len - leaf.borrow().key.len());
+                                self.nibble
+                                    .truncate(cur_len - leaf.read().unwrap().key.len());
                             }
 
                             Node::Extension(ref ext) => {
                                 let cur_len = self.nibble.len();
-                                self.nibble.truncate(cur_len - ext.borrow().prefix.len());
+                                self.nibble
+                                    .truncate(cur_len - ext.read().unwrap().prefix.len());
                             }
 
                             Node::Branch(_) => {
@@ -152,17 +152,20 @@ where
                     }
 
                     (TraceStatus::Doing, Node::Extension(ref ext)) => {
-                        self.nibble.extend(&ext.borrow().prefix);
-                        self.nodes.push((ext.borrow().node.clone()).into());
+                        self.nibble.extend(&ext.read().unwrap().prefix);
+                        self.nodes.push((ext.read().unwrap().node.clone()).into());
                     }
 
                     (TraceStatus::Doing, Node::Leaf(ref leaf)) => {
-                        self.nibble.extend(&leaf.borrow().key);
-                        return Some((self.nibble.encode_raw().0, leaf.borrow().value.clone()));
+                        self.nibble.extend(&leaf.read().unwrap().key);
+                        return Some((
+                            self.nibble.encode_raw().0,
+                            leaf.read().unwrap().value.clone(),
+                        ));
                     }
 
                     (TraceStatus::Doing, Node::Branch(ref branch)) => {
-                        let value_option = branch.borrow().value.clone();
+                        let value_option = branch.read().unwrap().value.clone();
                         if let Some(value) = value_option {
                             return Some((self.nibble.encode_raw().0, value));
                         } else {
@@ -171,7 +174,7 @@ where
                     }
 
                     (TraceStatus::Doing, Node::Hash(ref hash_node)) => {
-                        let node_hash = hash_node.borrow().hash;
+                        let node_hash = hash_node.read().unwrap().hash;
                         if let Ok(n) = self.trie.recover_from_db(node_hash) {
                             self.nodes.pop();
                             match n {
@@ -195,7 +198,7 @@ where
                             self.nibble.push(i);
                         }
                         self.nodes
-                            .push((branch.borrow().children[i as usize].clone()).into());
+                            .push((branch.read().unwrap().children[i as usize].clone()).into());
                     }
 
                     (_, Node::Empty) => {
@@ -424,7 +427,7 @@ where
         match source_node {
             Node::Empty => Ok(None),
             Node::Leaf(leaf) => {
-                let borrow_leaf = leaf.borrow();
+                let borrow_leaf = leaf.read().unwrap();
 
                 if &borrow_leaf.key == partial {
                     Ok(Some(borrow_leaf.value.clone()))
@@ -433,7 +436,7 @@ where
                 }
             }
             Node::Branch(branch) => {
-                let borrow_branch = branch.borrow();
+                let borrow_branch = branch.read().unwrap();
 
                 if partial.is_empty() || partial.at(0) == 16 {
                     Ok(borrow_branch.value.clone())
@@ -443,7 +446,7 @@ where
                 }
             }
             Node::Extension(extension) => {
-                let extension = extension.borrow();
+                let extension = extension.read().unwrap();
 
                 let prefix = &extension.prefix;
                 let match_len = partial.common_prefix(prefix);
@@ -454,7 +457,7 @@ where
                 }
             }
             Node::Hash(hash_node) => {
-                let node_hash = hash_node.borrow().hash;
+                let node_hash = hash_node.read().unwrap().hash;
                 let node =
                     self.recover_from_db(node_hash)?
                         .ok_or_else(|| TrieError::MissingTrieNode {
@@ -479,7 +482,7 @@ where
         match n {
             Node::Empty => Ok(Node::from_leaf(partial, value)),
             Node::Leaf(leaf) => {
-                let mut borrow_leaf = leaf.borrow_mut();
+                let mut borrow_leaf = leaf.write().unwrap();
 
                 let old_partial = &borrow_leaf.key;
                 let match_index = partial.common_prefix(old_partial);
@@ -504,17 +507,17 @@ where
                 branch.insert(partial.at(match_index), n);
 
                 if match_index == 0 {
-                    return Ok(Node::Branch(Rc::new(RefCell::new(branch))));
+                    return Ok(Node::Branch(Arc::new(RwLock::new(branch))));
                 }
 
                 // if include a common prefix
                 Ok(Node::from_extension(
                     partial.slice(0, match_index),
-                    Node::Branch(Rc::new(RefCell::new(branch))),
+                    Node::Branch(Arc::new(RwLock::new(branch))),
                 ))
             }
             Node::Branch(branch) => {
-                let mut borrow_branch = branch.borrow_mut();
+                let mut borrow_branch = branch.write().unwrap();
 
                 if partial.at(0) == 0x10 {
                     borrow_branch.value = Some(value);
@@ -527,7 +530,7 @@ where
                 Ok(Node::Branch(branch.clone()))
             }
             Node::Extension(ext) => {
-                let mut borrow_ext = ext.borrow_mut();
+                let mut borrow_ext = ext.write().unwrap();
 
                 let prefix = &borrow_ext.prefix;
                 let sub_node = borrow_ext.node.clone();
@@ -546,7 +549,7 @@ where
                             Node::from_extension(prefix.offset(1), sub_node)
                         },
                     );
-                    let node = Node::Branch(Rc::new(RefCell::new(branch)));
+                    let node = Node::Branch(Arc::new(RwLock::new(branch)));
 
                     return self.insert_at(node, path, path_index, value);
                 }
@@ -564,7 +567,7 @@ where
                 Ok(Node::Extension(ext.clone()))
             }
             Node::Hash(hash_node) => {
-                let node_hash = hash_node.borrow().hash;
+                let node_hash = hash_node.read().unwrap().hash;
                 self.passing_keys.insert(node_hash.as_bytes().to_vec());
                 let node =
                     self.recover_from_db(node_hash)?
@@ -589,7 +592,7 @@ where
         let (new_node, deleted) = match old_node {
             Node::Empty => Ok((Node::Empty, false)),
             Node::Leaf(leaf) => {
-                let borrow_leaf = leaf.borrow();
+                let borrow_leaf = leaf.read().unwrap();
 
                 if &borrow_leaf.key == partial {
                     return Ok((Node::Empty, true));
@@ -597,7 +600,7 @@ where
                 Ok((Node::Leaf(leaf.clone()), false))
             }
             Node::Branch(branch) => {
-                let mut borrow_branch = branch.borrow_mut();
+                let mut borrow_branch = branch.write().unwrap();
 
                 if partial.at(0) == 0x10 {
                     borrow_branch.value = None;
@@ -615,7 +618,7 @@ where
                 Ok((Node::Branch(branch.clone()), deleted))
             }
             Node::Extension(ext) => {
-                let mut borrow_ext = ext.borrow_mut();
+                let mut borrow_ext = ext.write().unwrap();
 
                 let prefix = &borrow_ext.prefix;
                 let match_len = partial.common_prefix(prefix);
@@ -634,7 +637,7 @@ where
                 }
             }
             Node::Hash(hash_node) => {
-                let hash = hash_node.borrow().hash;
+                let hash = hash_node.read().unwrap().hash;
                 self.passing_keys.insert(hash.as_bytes().to_vec());
 
                 let node =
@@ -662,7 +665,7 @@ where
     fn degenerate(&mut self, n: Node) -> TrieResult<Node> {
         match n {
             Node::Branch(branch) => {
-                let borrow_branch = branch.borrow();
+                let borrow_branch = branch.read().unwrap();
 
                 let mut used_indexs = vec![];
                 for (index, node) in borrow_branch.children.iter().enumerate() {
@@ -689,26 +692,26 @@ where
                 }
             }
             Node::Extension(ext) => {
-                let borrow_ext = ext.borrow();
+                let borrow_ext = ext.read().unwrap();
 
                 let prefix = &borrow_ext.prefix;
                 match borrow_ext.node.clone() {
                     Node::Extension(sub_ext) => {
-                        let borrow_sub_ext = sub_ext.borrow();
+                        let borrow_sub_ext = sub_ext.read().unwrap();
 
                         let new_prefix = prefix.join(&borrow_sub_ext.prefix);
                         let new_n = Node::from_extension(new_prefix, borrow_sub_ext.node.clone());
                         self.degenerate(new_n)
                     }
                     Node::Leaf(leaf) => {
-                        let borrow_leaf = leaf.borrow();
+                        let borrow_leaf = leaf.read().unwrap();
 
                         let new_prefix = prefix.join(&borrow_leaf.key);
                         Ok(Node::from_leaf(new_prefix, borrow_leaf.value.clone()))
                     }
                     // try again after recovering node from the db.
                     Node::Hash(hash_node) => {
-                        let node_hash = hash_node.borrow().hash;
+                        let node_hash = hash_node.read().unwrap().hash;
                         self.passing_keys.insert(node_hash.as_bytes().to_vec());
 
                         let new_node =
@@ -746,7 +749,7 @@ where
         match source_node {
             Node::Empty | Node::Leaf(_) => Ok(vec![]),
             Node::Branch(branch) => {
-                let borrow_branch = branch.borrow();
+                let borrow_branch = branch.read().unwrap();
 
                 if partial.is_empty() || partial.at(0) == 16 {
                     Ok(vec![])
@@ -756,7 +759,7 @@ where
                 }
             }
             Node::Extension(ext) => {
-                let borrow_ext = ext.borrow();
+                let borrow_ext = ext.read().unwrap();
 
                 let prefix = &borrow_ext.prefix;
                 let match_len = partial.common_prefix(prefix);
@@ -768,7 +771,7 @@ where
                 }
             }
             Node::Hash(hash_node) => {
-                let node_hash = hash_node.borrow().hash;
+                let node_hash = hash_node.read().unwrap().hash;
                 let n = self
                     .recover_from_db(node_hash)?
                     .ok_or(TrieError::MissingTrieNode {
@@ -828,7 +831,7 @@ where
     fn write_node(&mut self, to_encode: &Node) -> EncodedNode {
         // Returns the hash value directly to avoid double counting.
         if let Node::Hash(hash_node) = to_encode {
-            return EncodedNode::Hash(hash_node.borrow().hash);
+            return EncodedNode::Hash(hash_node.read().unwrap().hash);
         }
 
         let data = self.encode_raw(to_encode);
@@ -849,7 +852,7 @@ where
         match node {
             Node::Empty => rlp::NULL_RLP.to_vec(),
             Node::Leaf(leaf) => {
-                let borrow_leaf = leaf.borrow();
+                let borrow_leaf = leaf.read().unwrap();
 
                 let mut stream = RlpStream::new_list(2);
                 stream.append(&borrow_leaf.key.encode_compact());
@@ -857,7 +860,7 @@ where
                 stream.out()
             }
             Node::Branch(branch) => {
-                let borrow_branch = branch.borrow();
+                let borrow_branch = branch.read().unwrap();
 
                 let mut stream = RlpStream::new_list(17);
                 for i in 0..16 {
@@ -875,7 +878,7 @@ where
                 stream.out()
             }
             Node::Extension(ext) => {
-                let borrow_ext = ext.borrow();
+                let borrow_ext = ext.read().unwrap();
 
                 let mut stream = RlpStream::new_list(2);
                 stream.append(&borrow_ext.prefix.encode_compact());


### PR DESCRIPTION
trin gets grumpy about using this library, with all the `RefCell`s. It prefers types that are threadsafe (by implementing Send & Sync). So I replaced the RefCells with `RwLock`s. It comes at a performance cost, and there's surely a better way to do it, but this is the fastest (to code) solution I could come up with.

I would spend more time on it, but we'll move to Verkle tries sooner than later, I hope.