### PR TITLE
Remove unused contains() method in Trie DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -14,8 +14,6 @@ pub trait DB: Send + Sync {
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    fn contains(&self, key: &[u8]) -> Result<bool, Self::Error>;
-
     /// Insert data into the cache.
     fn insert(&self, key: &[u8], value: Vec<u8>) -> Result<(), Self::Error>;
 
@@ -81,10 +79,6 @@ impl DB for MemoryDB {
         Ok(())
     }
 
-    fn contains(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        Ok(self.storage.read().contains_key(key))
-    }
-
     fn remove(&self, key: &[u8]) -> Result<(), Self::Error> {
         if self.light {
             self.storage.write().remove(key);
@@ -120,21 +114,12 @@ mod tests {
     }
 
     #[test]
-    fn test_memdb_contains() {
-        let memdb = MemoryDB::new(true);
-        memdb.insert(b"test", b"test".to_vec()).unwrap();
-
-        let contains = memdb.contains(b"test").unwrap();
-        assert_eq!(contains, true)
-    }
-
-    #[test]
     fn test_memdb_remove() {
         let memdb = MemoryDB::new(true);
         memdb.insert(b"test", b"test".to_vec()).unwrap();
 
         memdb.remove(b"test").unwrap();
-        let contains = memdb.contains(b"test").unwrap();
-        assert_eq!(contains, false)
+        let contains = memdb.get(b"test").unwrap();
+        assert_eq!(contains, None)
     }
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -989,9 +989,9 @@ mod tests {
         // Manually corrupt the database by removing a trie node
         // This is the hash for the leaf node for test2-key
         let node_hash_to_delete = b"\xcb\x15v%j\r\x1e\te_TvQ\x8d\x93\x80\xd1\xa2\xd1\xde\xfb\xa5\xc3hJ\x8c\x9d\xb93I-\xbd";
-        assert!(corruptor_db.contains(node_hash_to_delete).unwrap());
+        assert_ne!(corruptor_db.get(node_hash_to_delete).unwrap(), None);
         corruptor_db.remove(node_hash_to_delete).unwrap();
-        assert!(!corruptor_db.contains(node_hash_to_delete).unwrap());
+        assert_eq!(corruptor_db.get(node_hash_to_delete).unwrap(), None);
 
         return (
             trie,


### PR DESCRIPTION
Might just rage-merge this so I can get it released and pulled into trin.

`contains()` doesn't seem to be an important part of the API (can just check if the result of `get()` is `None`). Nothing in trie seems to use it explicitly (just a couple tests).

Also, I didn't find an explicit `contains()` in the rocksdb API, when trying to implement the DB for trin. So it seems cleanest to simply remove it (at least for now).