### PR TITLE
New method at_root(root_hash), to replace from(db, root_hash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ fn main() -> Result<(), TrieError> {
     let value = b"test-value";
 
     let root = {
-        let mut trie = EthTrie::new(Arc::clone(&memdb));
+        let mut trie = EthTrie::new(memdb.clone());
         trie.insert(key, value)?;
 
         let v = trie.get(key)?;
@@ -38,7 +38,7 @@ fn main() -> Result<(), TrieError> {
     };
     assert_eq!(root.as_bytes(), b"\x0ee/\xd2Y,\x8aS}\xcf|0\x85L\xb2\x87\xea\xabt\x0c\x16\xd9G\x0c\xa3\xe0S\xf4\x9b}\xe3g");
 
-    let mut trie = EthTrie::from(Arc::clone(&memdb), root)?;
+    let mut trie = EthTrie::new(memdb).at_root(root);
 
     let exists = trie.contains(key)?;
     assert_eq!(exists, true);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,6 @@ pub enum TrieError {
     DB(String),
     Decoder(DecoderError),
     InvalidData,
-    InvalidStateRoot,
     InvalidProof,
     MissingTrieNode {
         node_hash: H256,
@@ -29,7 +28,6 @@ impl fmt::Display for TrieError {
             TrieError::DB(ref err) => format!("trie error: {:?}", err),
             TrieError::Decoder(ref err) => format!("trie error: {:?}", err),
             TrieError::InvalidData => "trie error: invalid data".to_owned(),
-            TrieError::InvalidStateRoot => "trie error: invalid state root".to_owned(),
             TrieError::InvalidProof => "trie error: invalid proof".to_owned(),
             TrieError::MissingTrieNode { .. } => "trie error: missing node".to_owned(),
         };

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,7 +16,8 @@ mod trie_tests {
         let root_hash = trie.root_hash().unwrap();
         let rs = format!("0x{}", hex::encode(root_hash.clone()));
         assert_eq!(rs.as_str(), hash);
-        let mut trie = EthTrie::from(Arc::clone(&memdb), root_hash).unwrap();
+
+        let mut trie = trie.at_root(root_hash);
         let r2 = trie.root_hash().unwrap();
         let rs2 = format!("0x{}", hex::encode(r2));
         assert_eq!(rs2.as_str(), hash);

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -234,30 +234,6 @@ where
         }
     }
 
-    pub fn from(db: Arc<D>, root: H256) -> TrieResult<Self> {
-        match db
-            .get(root.as_bytes())
-            .map_err(|e| TrieError::DB(e.to_string()))?
-        {
-            Some(data) => {
-                let mut trie = Self {
-                    root: Node::Empty,
-                    root_hash: root,
-
-                    cache: HashMap::new(),
-                    passing_keys: HashSet::new(),
-                    gen_keys: HashSet::new(),
-
-                    db,
-                };
-
-                trie.root = trie.decode_node(&data)?;
-                Ok(trie)
-            }
-            None => Err(TrieError::InvalidStateRoot),
-        }
-    }
-
     pub fn at_root(&self, root_hash: H256) -> Self {
         Self {
             root: Node::from_hash(root_hash),
@@ -409,15 +385,15 @@ where
         key: &[u8],
         proof: Vec<Vec<u8>>,
     ) -> TrieResult<Option<Vec<u8>>> {
-        let memdb = Arc::new(MemoryDB::new(true));
+        let proof_db = Arc::new(MemoryDB::new(true));
         for node_encoded in proof.into_iter() {
             let hash = keccak(&node_encoded);
 
             if root_hash.eq(&hash) || node_encoded.len() >= HASHED_LENGTH {
-                memdb.insert(hash.as_bytes(), node_encoded).unwrap();
+                proof_db.insert(hash.as_bytes(), node_encoded).unwrap();
             }
         }
-        let trie = EthTrie::from(memdb, root_hash).or(Err(TrieError::InvalidProof))?;
+        let trie = EthTrie::new(proof_db).at_root(root_hash);
         trie.get(key).or(Err(TrieError::InvalidProof))
     }
 }
@@ -1182,10 +1158,10 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_from_root() {
+    fn test_trie_at_root_six_keys() {
         let memdb = Arc::new(MemoryDB::new(true));
         let root = {
-            let mut trie = EthTrie::new(Arc::clone(&memdb));
+            let mut trie = EthTrie::new(memdb.clone());
             trie.insert(b"test", b"test").unwrap();
             trie.insert(b"test1", b"test").unwrap();
             trie.insert(b"test2", b"test").unwrap();
@@ -1195,7 +1171,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::from(Arc::clone(&memdb), root).unwrap();
+        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
         let v1 = trie.get(b"test33").unwrap();
         assert_eq!(Some(b"test".to_vec()), v1);
         let v2 = trie.get(b"test44").unwrap();
@@ -1205,7 +1181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_from_root_and_insert() {
+    fn test_trie_at_root_and_insert() {
         let memdb = Arc::new(MemoryDB::new(true));
         let root = {
             let mut trie = EthTrie::new(Arc::clone(&memdb));
@@ -1218,7 +1194,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::from(Arc::clone(&memdb), root).unwrap();
+        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
         trie.insert(b"test55", b"test55").unwrap();
         trie.root_hash().unwrap();
         let v = trie.get(b"test55").unwrap();
@@ -1226,7 +1202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_from_root_and_delete() {
+    fn test_trie_at_root_and_delete() {
         let memdb = Arc::new(MemoryDB::new(true));
         let root = {
             let mut trie = EthTrie::new(Arc::clone(&memdb));
@@ -1239,7 +1215,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::from(Arc::clone(&memdb), root).unwrap();
+        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
         let removed = trie.remove(b"test44").unwrap();
         assert_eq!(true, removed);
         let removed = trie.remove(b"test33").unwrap();
@@ -1278,7 +1254,7 @@ mod tests {
             trie1.insert(k1.as_bytes(), v.as_bytes()).unwrap();
             trie1.root_hash().unwrap();
             let root = trie1.root_hash().unwrap();
-            let mut trie2 = EthTrie::from(Arc::clone(&memdb), root).unwrap();
+            let mut trie2 = trie1.at_root(root);
             trie2.remove(&k1.as_bytes()).unwrap();
             trie2.root_hash().unwrap()
         };
@@ -1392,7 +1368,7 @@ mod tests {
             assert!(kv2.is_empty());
         }
 
-        let trie = EthTrie::from(memdb, root1).unwrap();
+        let trie = EthTrie::new(memdb).at_root(root1);
         trie.iter()
             .for_each(|(k, v)| assert_eq!(kv.remove(&k).unwrap(), v));
         assert!(kv.is_empty());


### PR DESCRIPTION
New method `at_root(root_hash)`, to replace `from(db, root_hash)`. Why force the caller to get a reference to the database any time they want to change the viewed root-hash of the trie? So we use a new method `at_root` instead, that reuses the existing database.

Fixes #20 

Also, stop trying to load the root node right away. Just complain if it's missing the same way that you would complain if any node is missing, on `get()`, `insert()`, etc.

That means we can drop the unused error `InvalidStateRoot`