### PR TITLE
Run clippy on test code, Security upgrade for Rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 orbs:
-  rust: circleci/rust@1.5.0
+  rust: circleci/rust@1.6.0
 jobs:
   lint-build-test:
         description: |
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.55.0
+            tag: 1.56.1
         environment:
             RUSTFLAGS: '-D warnings'
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
                 command: rustup component add clippy
             - run:
                 name: Run Clippy
-                command: cargo clippy --all -- --deny warnings
+                command: cargo clippy --all --all-targets --all-features -- --deny warnings
             - run:
                 name: Build workspace
                 command: cargo build --workspace --jobs 2

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -169,7 +169,7 @@ mod tests {
         let compact = n.encode_compact();
         let n2 = Nibbles::from_compact(&compact);
         let (raw, is_leaf) = n2.encode_raw();
-        assert_eq!(is_leaf, true);
+        assert!(is_leaf);
         assert_eq!(raw, b"key1");
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -599,12 +599,12 @@ mod trie_tests {
         // empty proof
         let proof = vec![];
         let value = trie.verify_proof(root, b"doe", proof);
-        assert_eq!(value.is_err(), true);
+        assert!(value.is_err());
 
         // bad proof
         let proof = vec![b"aaa".to_vec(), b"ccc".to_vec()];
         let value = trie.verify_proof(root, b"doe", proof);
-        assert_eq!(value.is_err(), true);
+        assert!(value.is_err());
     }
 
     #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,7 +14,7 @@ mod trie_tests {
             trie.insert(k, v).unwrap();
         }
         let root_hash = trie.root_hash().unwrap();
-        let rs = format!("0x{}", hex::encode(root_hash.clone()));
+        let rs = format!("0x{}", hex::encode(root_hash));
         assert_eq!(rs.as_str(), hash);
 
         let mut trie = trie.at_root(root_hash);
@@ -575,7 +575,7 @@ mod trie_tests {
                 .collect::<Vec<_>>(),
             expected
         );
-        let value = trie.verify_proof(root.clone(), b"doe", proof).unwrap();
+        let value = trie.verify_proof(root, b"doe", proof).unwrap();
         assert_eq!(value, Some(b"reindeer".to_vec()));
 
         // proof of key not exist
@@ -593,17 +593,17 @@ mod trie_tests {
                 .collect::<Vec<_>>(),
             expected
         );
-        let value = trie.verify_proof(root.clone(), b"dogg", proof).unwrap();
+        let value = trie.verify_proof(root, b"dogg", proof).unwrap();
         assert_eq!(value, None);
 
         // empty proof
         let proof = vec![];
-        let value = trie.verify_proof(root.clone(), b"doe", proof);
+        let value = trie.verify_proof(root, b"doe", proof);
         assert_eq!(value.is_err(), true);
 
         // bad proof
         let proof = vec![b"aaa".to_vec(), b"ccc".to_vec()];
-        let value = trie.verify_proof(root.clone(), b"doe", proof);
+        let value = trie.verify_proof(root, b"doe", proof);
         assert_eq!(value.is_err(), true);
     }
 
@@ -626,7 +626,7 @@ mod trie_tests {
         let root = trie.root_hash().unwrap();
         for k in keys.into_iter() {
             let proof = trie.get_proof(&k).unwrap();
-            let value = trie.verify_proof(root.clone(), &k, proof).unwrap().unwrap();
+            let value = trie.verify_proof(root, &k, proof).unwrap().unwrap();
             assert_eq!(value, k);
         }
     }
@@ -648,17 +648,13 @@ mod trie_tests {
         let root = trie.root_hash().unwrap();
         let proof = trie.get_proof(b"k").unwrap();
         assert_eq!(proof.len(), 1);
-        let value = trie
-            .verify_proof(root.clone(), b"k", proof.clone())
-            .unwrap();
+        let value = trie.verify_proof(root, b"k", proof.clone()).unwrap();
         assert_eq!(value, Some(b"v".to_vec()));
 
         // remove key does not affect the verify process
         trie.remove(b"k").unwrap();
         let _root = trie.root_hash().unwrap();
-        let value = trie
-            .verify_proof(root.clone(), b"k", proof.clone())
-            .unwrap();
+        let value = trie.verify_proof(root, b"k", proof).unwrap();
         assert_eq!(value, Some(b"v".to_vec()));
     }
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1170,7 +1170,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
+        let mut trie = EthTrie::new(memdb).at_root(root);
         let v1 = trie.get(b"test33").unwrap();
         assert_eq!(Some(b"test".to_vec()), v1);
         let v2 = trie.get(b"test44").unwrap();
@@ -1193,7 +1193,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
+        let mut trie = EthTrie::new(memdb).at_root(root);
         trie.insert(b"test55", b"test55").unwrap();
         trie.root_hash().unwrap();
         let v = trie.get(b"test55").unwrap();
@@ -1214,7 +1214,7 @@ mod tests {
             trie.root_hash().unwrap()
         };
 
-        let mut trie = EthTrie::new(memdb.clone()).at_root(root);
+        let mut trie = EthTrie::new(memdb).at_root(root);
         let removed = trie.remove(b"test44").unwrap();
         assert!(removed);
         let removed = trie.remove(b"test33").unwrap();
@@ -1380,7 +1380,7 @@ mod tests {
         trie.insert(b"key", b"val").unwrap();
         let new_root_hash = trie.commit().unwrap();
 
-        let empty_trie = EthTrie::new(memdb.clone());
+        let empty_trie = EthTrie::new(memdb);
         // Can't find key in new trie at empty root
         assert_eq!(empty_trie.get(b"key").unwrap(), None);
 
@@ -1402,7 +1402,7 @@ mod tests {
         .unwrap();
         let new_root_hash = trie.commit().unwrap();
 
-        let empty_trie = EthTrie::new(memdb.clone());
+        let empty_trie = EthTrie::new(memdb);
         // Can't find key in new trie at empty root
         assert_eq!(empty_trie.get(b"pretty-long-key").unwrap(), None);
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -930,7 +930,6 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
-    use ethereum_types;
     use keccak_hash::{keccak, H256};
 
     use super::{EthTrie, Trie};
@@ -982,11 +981,11 @@ mod tests {
         corruptor_db.remove(node_hash_to_delete).unwrap();
         assert_eq!(corruptor_db.get(node_hash_to_delete).unwrap(), None);
 
-        return (
+        (
             trie,
             actual_root_hash,
             H256::from_slice(node_hash_to_delete),
-        );
+        )
     }
 
     #[test]
@@ -1255,7 +1254,7 @@ mod tests {
             trie1.root_hash().unwrap();
             let root = trie1.root_hash().unwrap();
             let mut trie2 = trie1.at_root(root);
-            trie2.remove(&k1.as_bytes()).unwrap();
+            trie2.remove(k1.as_bytes()).unwrap();
             trie2.root_hash().unwrap()
         };
 
@@ -1326,7 +1325,7 @@ mod tests {
             let mut trie = EthTrie::new(memdb.clone());
             let mut kv = kv.clone();
             kv.iter().for_each(|(k, v)| {
-                trie.insert(&k, &v).unwrap();
+                trie.insert(k, v).unwrap();
             });
             root1 = trie.root_hash().unwrap();
 
@@ -1346,7 +1345,7 @@ mod tests {
             kv2.insert(b"test16".to_vec(), b"test16".to_vec());
             kv2.insert(b"test2".to_vec(), b"test17".to_vec());
             kv2.iter().for_each(|(k, v)| {
-                trie.insert(&k, &v).unwrap();
+                trie.insert(k, v).unwrap();
             });
 
             trie.root_hash().unwrap();
@@ -1357,7 +1356,7 @@ mod tests {
             kv_delete.insert(b"test14".to_vec());
 
             kv_delete.iter().for_each(|k| {
-                trie.remove(&k).unwrap();
+                trie.remove(k).unwrap();
             });
 
             kv2.retain(|k, _| !kv_delete.contains(k));

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1128,8 +1128,8 @@ mod tests {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(memdb);
         trie.insert(b"test", b"test").unwrap();
-        assert_eq!(true, trie.contains(b"test").unwrap());
-        assert_eq!(false, trie.contains(b"test2").unwrap());
+        assert!(trie.contains(b"test").unwrap());
+        assert!(!trie.contains(b"test2").unwrap());
     }
 
     #[test]
@@ -1138,7 +1138,7 @@ mod tests {
         let mut trie = EthTrie::new(memdb);
         trie.insert(b"test", b"test").unwrap();
         let removed = trie.remove(b"test").unwrap();
-        assert_eq!(true, removed)
+        assert!(removed)
     }
 
     #[test]
@@ -1152,7 +1152,7 @@ mod tests {
             trie.insert(val, val).unwrap();
 
             let removed = trie.remove(val).unwrap();
-            assert_eq!(true, removed);
+            assert!(removed);
         }
     }
 
@@ -1216,11 +1216,11 @@ mod tests {
 
         let mut trie = EthTrie::new(memdb.clone()).at_root(root);
         let removed = trie.remove(b"test44").unwrap();
-        assert_eq!(true, removed);
+        assert!(removed);
         let removed = trie.remove(b"test33").unwrap();
-        assert_eq!(true, removed);
+        assert!(removed);
         let removed = trie.remove(b"test23").unwrap();
-        assert_eq!(true, removed);
+        assert!(removed);
     }
 
     #[test]


### PR DESCRIPTION
- Run clippy on the test code
- Fix all the clippy warnings
- Upgrade Rust to v1.56.1 for https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html
- Fix clippy warnings for new version