### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ homepage = "https://github.com/carver/eth-trie.rs"
 documentation = "https://docs.rs/eth_trie"
 
 [dependencies]
-hashbrown = "0.12.0"
-keccak-hash = "0.9"
-log = "0.4.16"
-parking_lot = "0.12"
-rlp = "0.5.1"
+hashbrown = "0.14.0"
+keccak-hash = "0.10.0"
+log = "0.4.19"
+parking_lot = "0.12.1"
+rlp = "0.5.2"
 
 [dev-dependencies]
-rand = "0.8.3"
-hex = "0.4.2"
-criterion = "0.3.5"
-ethereum-types = "0.13.1"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+rand = "0.8.5"
+hex = "0.4.3"
+criterion = "0.5.1"
+ethereum-types = "0.14.1"
+uuid = { version = "1.3.4", features = ["serde", "v4"] }
 
 [[bench]]
 name = "trie"


### PR DESCRIPTION
Update all dependencies to their latest versions. Everything still builds, tests pass and benches run. This is quite useful for the `ethereum-types` dependency which is exposed in the public API.