### PR TITLE
Clippy warnings and null hash elision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.56.1
+            tag: 1.64.0
         environment:
             RUSTFLAGS: '-D warnings'
         steps:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TrieError {
     DB(String),
     Decoder(DecoderError),

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,3 +1,4 @@
+use keccak_hash::KECCAK_NULL_RLP;
 use std::sync::{Arc, RwLock};
 
 use hashbrown::{HashMap, HashSet};
@@ -224,7 +225,7 @@ where
     pub fn new(db: Arc<D>) -> Self {
         Self {
             root: Node::Empty,
-            root_hash: keccak(&rlp::NULL_RLP.to_vec()),
+            root_hash: KECCAK_NULL_RLP,
 
             cache: HashMap::new(),
             passing_keys: HashSet::new(),
@@ -862,7 +863,7 @@ where
         }
     }
 
-    fn decode_node(&self, data: &[u8]) -> TrieResult<Node> {
+    fn decode_node(data: &[u8]) -> TrieResult<Node> {
         let r = Rlp::new(data);
 
         match r.prototype()? {
@@ -874,7 +875,7 @@ where
                 if key.is_leaf() {
                     Ok(Node::from_leaf(key, r.at(1)?.data()?.to_vec()))
                 } else {
-                    let n = self.decode_node(r.at(1)?.as_raw())?;
+                    let n = Self::decode_node(r.at(1)?.as_raw())?;
 
                     Ok(Node::from_extension(key, n))
                 }
@@ -884,7 +885,7 @@ where
                 #[allow(clippy::needless_range_loop)]
                 for i in 0..nodes.len() {
                     let rlp_data = r.at(i)?;
-                    let n = self.decode_node(rlp_data.as_raw())?;
+                    let n = Self::decode_node(rlp_data.as_raw())?;
                     nodes[i] = n;
                 }
 
@@ -915,7 +916,7 @@ where
             .get(key.as_bytes())
             .map_err(|e| TrieError::DB(e.to_string()))?
         {
-            Some(value) => Some(self.decode_node(&value)?),
+            Some(value) => Some(Self::decode_node(&value)?),
             None => None,
         };
         Ok(node)
@@ -930,7 +931,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
-    use keccak_hash::{keccak, H256};
+    use keccak_hash::{H256, KECCAK_NULL_RLP};
 
     use super::{EthTrie, Trie};
     use crate::db::{MemoryDB, DB};
@@ -1293,7 +1294,7 @@ mod tests {
         }
         trie.root_hash().unwrap();
 
-        let empty_node_key = keccak(&rlp::NULL_RLP);
+        let empty_node_key = KECCAK_NULL_RLP;
         let value = trie.db.get(empty_node_key.as_ref()).unwrap().unwrap();
         assert_eq!(value, &rlp::NULL_RLP)
     }


### PR DESCRIPTION
Slightly simplifies recursion and avoids an unnecessary empty hash calculation.