### PR TITLE
Release new version `0.2.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             Check linting with Clippy and rustfmt, build the crate, and run tests.
         executor:
             name: rust/default
-            tag: 1.64.0
+            tag: 1.71.1
         environment:
             RUSTFLAGS: '-D warnings'
         steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth_trie"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jason Carver <ut96caarrs@snkmail.com>"]
 description = "Ethereum-compatible Merkle-Patricia Trie."
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/carver/eth-trie.rs"
 documentation = "https://docs.rs/eth_trie"
 
 [dependencies]
-hashbrown = "0.12.0"
-keccak-hash = "0.9"
+hashbrown = "0.14.0"
+keccak-hash = "0.10.0"
 log = "0.4.16"
 parking_lot = "0.12"
 rlp = "0.5.1"
@@ -21,9 +21,9 @@ rlp = "0.5.1"
 [dev-dependencies]
 rand = "0.8.3"
 hex = "0.4.2"
-criterion = "0.3.5"
-ethereum-types = "0.13.1"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+criterion = "0.5.1"
+ethereum-types = "0.14.1"
+uuid = { version = "1.4.1", features = ["serde", "v4"] }
 
 [[bench]]
 name = "trie"


### PR DESCRIPTION
### What was wrong?

Trin gives us a compile warning: `the following packages contain code that will be rejected by a future version of Rust: uint v0.4.1`. 

This is because we use an `eth-trie.rs` version with outdated rlp version `0.3.0`

### How was it fixed?
- Update all dependencies to the latest version - this is not required to fix the issues but I think it is nice to add before releasing a new version.
- Fix clippy warning  - version `clippy 0.1.71 (eb26296 2023-08-03)`
- Update crate version to 0.2.0
- Update CircleCI rust version