### PR TITLE
feat!: use ethereum-types::H256, not keccak-hash::

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/carver/eth-trie.rs"
 documentation = "https://docs.rs/eth_trie"
 
 [dependencies]
+ethereum-types = "0.12.1"
 hashbrown = "0.14.0"
 keccak-hash = "0.10.0"
 log = "0.4.16"
@@ -22,7 +23,6 @@ rlp = "0.5.1"
 rand = "0.8.3"
 hex = "0.4.2"
 criterion = "0.5.1"
-ethereum-types = "0.14.1"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 
 [[bench]]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fmt;
 
-use keccak_hash::H256;
+use ethereum_types::H256;
 use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use keccak_hash::H256;
+use ethereum_types::H256;
 
 use crate::nibbles::Nibbles;
 


### PR DESCRIPTION
The ethereum-types version has an implementation for ssz encode and decode (but only at the v0.12.1 release, it seems to be removed in later releases).

Fixes #30 